### PR TITLE
compile errors about ros.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PCL REQUIRED)
 
 include_directories(
+	include ${catkin_INCLUDE_DIRS}
         ${SWEEP_SDK_PATH}/inc
         ${SWEEP_SDK_PATH}/inc/serial
         ${SWEEP_SDK_PATH}/src


### PR DESCRIPTION
```
/tmp/ros-install-this.6AZSZV/src/sweep_ros/src/node.cpp:25:21: fatal error: ros/ros.h: No such file or directory
compilation terminated.

```