### PR TITLE
Increase motor speed command buffer sizes to accomodate null character 

### DIFF
--- a/sweep-sdk-cpp/src/sweep_driver.cc
+++ b/sweep-sdk-cpp/src/sweep_driver.cc
@@ -259,8 +259,8 @@ status SweepDriver::resetSweep()
 status SweepDriver::changeMotorSpeed(uint8_t value)
 {
     sweep_response_param_t resp;
-    char cmd[4];
-    char speed[2];
+    char cmd[5];
+    char speed[3];
 
     if (!isConnected())
         return S_FAIL;


### PR DESCRIPTION
This pull request fixes a buffer overflow error, which I observed on Ubuntu 14.04 with ROS Indigo. The backtrace and memory maps for the error are shown below:

```
*** buffer overflow detected ***: /home/bhavya/Maidbot/catkin_ws/devel/lib/sweep_ros/sweep_node terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x7329f)[0x7f8990a8a29f]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x5c)[0x7f8990b21bbc]
/lib/x86_64-linux-gnu/libc.so.6(+0x109a90)[0x7f8990b20a90]
/home/bhavya/Maidbot/catkin_ws/devel/lib/sweep_ros/sweep_node(_ZN11SweepDriver16changeMotorSpeedEh+0x157)[0x40e617]
/home/bhavya/Maidbot/catkin_ws/devel/lib/sweep_ros/sweep_node(main+0x405)[0x408c25]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7f8990a38f45]
/home/bhavya/Maidbot/catkin_ws/devel/lib/sweep_ros/sweep_node[0x40979f]
======= Memory map: ========
00400000-00415000 r-xp 00000000 08:05 16655233                           /home/bhavya/Maidbot/catkin_ws/devel/.private/sweep_ros/lib/sweep_ros/sweep_node
00615000-00616000 r--p 00015000 08:05 16655233                           /home/bhavya/Maidbot/catkin_ws/devel/.private/sweep_ros/lib/sweep_ros/sweep_node
00616000-00617000 rw-p 00016000 08:05 16655233                           /home/bhavya/Maidbot/catkin_ws/devel/.private/sweep_ros/lib/sweep_ros/sweep_node
018af000-018e1000 rw-p 00000000 00:00 0                                  [heap]
7f897c000000-7f897c021000 rw-p 00000000 00:00 0 
7f897c021000-7f8980000000 ---p 00000000 00:00 0 
7f8984000000-7f8984021000 rw-p 00000000 00:00 0 
7f8984021000-7f8988000000 ---p 00000000 00:00 0 
7f8989d0c000-7f8989d0d000 ---p 00000000 00:00 0 
7f8989d0d000-7f898a50d000 rw-p 00000000 00:00 0                          [stack:30258]
7f898a50d000-7f898a50e000 ---p 00000000 00:00 0 
7f898a50e000-7f898ad0e000 rw-p 00000000 00:00 0                          [stack:30253]
7f898ad0e000-7f898ad0f000 ---p 00000000 00:00 0 
7f898ad0f000-7f898b50f000 rw-p 00000000 00:00 0                          [stack:30252]
7f898b50f000-7f898b510000 ---p 00000000 00:00 0 
7f898b510000-7f898bd10000 rw-p 00000000 00:00 0                          [stack:30251]
7f898bd10000-7f898bd1a000 r-xp 00000000 08:05 21500864                   /lib/x86_64-linux-gnu/libnss_files-2.19.so
7f898bd1a000-7f898bf19000 ---p 0000a000 08:05 21500864                   /lib/x86_64-linux-gnu/libnss_files-2.19.so
7f898bf19000-7f898bf1a000 r--p 00009000 08:05 21500864                   /lib/x86_64-linux-gnu/libnss_files-2.19.so
7f898bf1a000-7f898bf1b000 rw-p 0000a000 08:05 21500864                   /lib/x86_64-linux-gnu/libnss_files-2.19.so
7f898bf1b000-7f898c5fd000 r--p 00000000 08:05 4725344                    /usr/lib/locale/locale-archive
7f898c5fd000-7f898dc69000 r-xp 00000000 08:05 4725880                    /usr/lib/x86_64-linux-gnu/libicudata.so.52.1
7f898dc69000-7f898de68000 ---p 0166c000 08:05 4725880                    /usr/lib/x86_64-linux-gnu/libicudata.so.52.1
7f898de68000-7f898de69000 r--p 0166b000 08:05 4725880                    /usr/lib/x86_64-linux-gnu/libicudata.so.52.1
7f898de69000-7f898de6a000 rw-p 0166c000 08:05 4725880                    /usr/lib/x86_64-linux-gnu/libicudata.so.52.1
7f898de6a000-7f898de6d000 r-xp 00000000 08:05 21500844                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f898de6d000-7f898e06c000 ---p 00003000 08:05 21500844                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f898e06c000-7f898e06d000 r--p 00002000 08:05 21500844                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f898e06d000-7f898e06e000 rw-p 00003000 08:05 21500844                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f898e06e000-7f898e072000 r-xp 00000000 08:05 21496899                   /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f898e072000-7f898e271000 ---p 00004000 08:05 21496899                   /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f898e271000-7f898e272000 r--p 00003000 08:05 21496899                   /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f898e272000-7f898e273000 rw-p 00004000 08:05 21496899                   /lib/x86_64-linux-gnu/libuuid.so.1.3.0
7f898e273000-7f898e29a000 r-xp 00000000 08:05 21500062                   /lib/x86_64-linux-gnu/libexpat.so.1.6.0
7f898e29a000-7f898e49a000 ---p 00027000 08:05 21500062                   /lib/x86_64-linux-gnu/libexpat.so.1.6.0
7f898e49a000-7f898e49c000 r--p 00027000 08:05 21500062                   /lib/x86_64-linux-gnu/libexpat.so.1.6.0
7f898e49c000-7f898e49d000 rw-p 00029000 08:05 21500062                   /lib/x86_64-linux-gnu/libexpat.so.1.6.0
7f898e49d000-7f898e4a6000 r-xp 00000000 08:05 21500845                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f898e4a6000-7f898e6a6000 ---p 00009000 08:05 21500845                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f898e6a6000-7f898e6a7000 r--p 00009000 08:05 21500845                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f898e6a7000-7f898e6a8000 rw-p 0000a000 08:05 21500845                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f898e6a8000-7f898e6d6000 rw-p 00000000 00:00 0 
7f898e6d6000-7f898e8ce000 r-xp 00000000 08:05 4725873                    /usr/lib/x86_64-linux-gnu/libicui18n.so.52.1
7f898e8ce000-7f898eace000 ---p 001f8000 08:05 4725873                    /usr/lib/x86_64-linux-gnu/libicui18n.so.52.1
7f898eace000-7f898eadb000 r--p 001f8000 08:05 4725873                    /usr/lib/x86_64-linux-gnu/libicui18n.so.52.1
7f898eadb000-7f898eadc000 rw-p 00205000 08:05 4725873                    /usr/lib/x86_64-linux-gnu/libicui18n.so.52.1
7f898eadc000-7f898eadd000 rw-p 00000000 00:00 0 
7f898eadd000-7f898ec41000 r-xp 00000000 08:05 4725875                    /usr/lib/x86_64-linux-gnu/libicuuc.so.52.1
7f898ec41000-7f898ee40000 ---p 00164000 08:05 4725875                    /usr/lib/x86_64-linux-gnu/libicuuc.so.52.1
7f898ee40000-7f898ee51000 r--p 00163000 08:05 4725875                    /usr/lib/x86_64-linux-gnu/libicuuc.so.52.1
7f898ee51000-7f898ee52000 rw-p 00174000 08:05 4725875                    /usr/lib/x86_64-linux-gnu/libicuuc.so.52.1
7f898ee52000-7f898ee56000 rw-p 00000000 00:00 0 
7f898ee56000-7f898ee86000 r-xp 00000000 08:05 4720848                    /usr/lib/x86_64-linux-gnu/libapr-1.so.0.5.1
7f898ee86000-7f898f085000 ---p 00030000 08:05 4720848                    /usr/lib/x86_64-linux-gnu/libapr-1.so.0.5.1
7f898f085000-7f898f086000 r--p 0002f000 08:05 4720848                    /usr/lib/x86_64-linux-gnu/libapr-1.so.0.5.1
7f898f086000-7f898f087000 rw-p 00030000 08:05 4720848                    /usr/lib/x86_64-linux-gnu/libapr-1.so.0.5.1
7f898f087000-7f898f0ad000 r-xp 00000000 08:05 4720850                    /usr/lib/x86_64-linux-gnu/libaprutil-1.so.0.5.3
7f898f0ad000-7f898f2ac000 ---p 00026000 08:05 4720850                    /usr/lib/x86_64-linux-gnu/libaprutil-1.so.0.5.3
7f898f2ac000-7f898f2ad000 r--p 00025000 08:05 4720850                    /usr/lib/x86_64-linux-gnu/libaprutil-1.so.0.5.3
7f898f2ad000-7f898f2ae000 rw-p 00026000 08:05 4720850                    /usr/lib/x86_64-linux-gnu/libaprutil-1.so.0.5.3
7f898f2ae000-7f898f2b6000 r-xp 00000000 08:05 4726886                    /usr/lib/x86_64-linux-gnu/libconsole_bridge.so.0.2
7f898f2b6000-7f898f4b6000 ---p 00008000 08:05 4726886                    /usr/lib/x86_64-linux-gnu/libconsole_bridge.so.0.2
7f898f4b6000-7f898f4b7000 r--p 00008000 08:05 4726886                    /usr/lib/x86_64-linux-gnu/libconsole_bridge.so.0.2
7f898f4b7000-7f898f4b8000 rw-p 00009000 08:05 4726886                    /usr/lib/x86_64-linux-gnu/libconsole_bridge.so.0.2
7f898f4b8000-7f898f4bf000 r-xp 00000000 08:05 21500859                   /lib/x86_64-linux-gnu/librt-2.19.so
7f898f4bf000-7f898f6be000 ---p 00007000 08:05 21500859                   /lib/x86_64-linux-gnu/librt-2.19.so
7f898f6be000-7f898f6bf000 r--p 00006000 08:05 21500859                   /lib/x86_64-linux-gnu/librt-2.19.so
7f898f6bf000-7f898f6c0000 rw-p 00007000 08:05 21500859                   /lib/x86_64-linux-gnu/librt-2.19.so
7f898f6c0000-7f898f7c1000 r-xp 00000000 08:05 4720893                    /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.54.0
7f898f7c1000-7f898f9c0000 ---p 00101000 08:05 4720893                    /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.54.0
7f898f9c0000-7f898f9c5000 r--p 00100000 08:05 4720893                    /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.54.0
7f898f9c5000-7f898f9c6000 rw-p 00105000 08:05 4720893                    /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.54.0
7f898f9c6000-7f898f9c7000 rw-p 00000000 00:00 0 
7f898f9c7000-7f898fb81000 r-xp 00000000 08:05 4729695                    /usr/lib/liblog4cxx.so.10.0.0
7f898fb81000-7f898fd80000 ---p 001ba000 08:05 4729695                    /usr/lib/liblog4cxx.so.10.0.0
7f898fd80000-7f898fdaa000 r--p 001b9000 08:05 4729695                    /usr/lib/liblog4cxx.so.10.0.0
7f898fdaa000-7f898fdad000 rw-p 001e3000 08:05 4729695                    /usr/lib/liblog4cxx.so.10.0.0
7f898fdad000-7f898fdaf000 rw-p 00000000 00:00 0 
7f898fdaf000-7f898fdb0000 r-xp 00000000 08:05 20447439                   /opt/ros/indigo/lib/librosconsole_backend_interface.so
7f898fdb0000-7f898ffaf000 ---p 00001000 08:05 20447439                   /opt/ros/indigo/lib/librosconsole_backend_interface.so
7f898ffaf000-7f898ffb0000 r--p 00000000 08:05 20447439                   /opt/ros/indigo/lib/librosconsole_backend_interface.so
7f898ffb0000-7f898ffb1000 rw-p 00001000 08:05 20447439                   /opt/ros/indigo/lib/librosconsole_backend_interface.so
7f898ffb1000-7f898ffc2000 r-xp 00000000 08:05 20447438                   /opt/ros/indigo/lib/librosconsole_log4cxx.so
7f898ffc2000-7f89901c2000 ---p 00011000 08:05 20447438                   /opt/ros/indigo/lib/librosconsole_log4cxx.so
7f89901c2000-7f89901c4000 r--p 00011000 08:05 20447438                   /opt/ros/indigo/lib/librosconsole_log4cxx.so
7f89901c4000-7f89901c5000 rw-p 00013000 08:05 20447438                   /opt/ros/indigo/lib/librosconsole_log4cxx.so
7f89901c5000-7f89901da000 r-xp 00000000 08:05 4720855                    /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.54.0
7f89901da000-7f89903d9000 ---p 00015000 08:05 4720855                    /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.54.0
7f89903d9000-7f89903da000 r--p 00014000 08:05 4720855                    /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.54.0
7f89903da000-7f89903db000 rw-p 00015000 08:05 4720855                    /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.54.0
7f89903db000-7f89903ef000 r-xp 00000000 08:05 4720896                    /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.54.0
7f89903ef000-7f89905ee000 ---p 00014000 08:05 4720896                    /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.54.0
7f89905ee000-7f89905f0000 r--p 00013000 08:05 4720896                    /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.54.0
7f89905f0000-7f89905f1000 rw-p 00015000 08:05 4720896                    /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.54.0
7f89905f1000-7f89905f8000 r-xp 00000000 08:05 20447328                   /opt/ros/indigo/lib/libcpp_common.so
7f89905f8000-7f89907f7000 ---p 00007000 08:05 20447328                   /opt/ros/indigo/lib/libcpp_common.so
7f89907f7000-7f89907f8000 r--p 00006000 08:05 20447328                   /opt/ros/indigo/lib/libcpp_common.so
7f89907f8000-7f89907f9000 rw-p 00007000 08:05 20447328                   /opt/ros/indigo/lib/libcpp_common.so
7f89907f9000-7f8990816000 r-xp 00000000 08:05 20447494                   /opt/ros/indigo/lib/libxmlrpcpp.so
7f8990816000-7f8990a15000 ---p 0001d000 08:05 20447494                   /opt/ros/indigo/lib/libxmlrpcpp.so
7f8990a15000-7f8990a16000 r--p 0001c000 08:05 20447494                   /opt/ros/indigo/lib/libxmlrpcpp.so
7f8990a16000-7f8990a17000 rw-p 0001d000 08:05 20447494                   /opt/ros/indigo/lib/libxmlrpcpp.so
7f8990a17000-7f8990bd1000 r-xp 00000000 08:05 21500860                   /lib/x86_64-linux-gnu/libc-2.19.so
7f8990bd1000-7f8990dd1000 ---p 001ba000 08:05 21500860                   /lib/x86_64-linux-gnu/libc-2.19.so
7f8990dd1000-7f8990dd5000 r--p 001ba000 08:05 21500860                   /lib/x86_64-linux-gnu/libc-2.19.so
7f8990dd5000-7f8990dd7000 rw-p 001be000 08:05 21500860                   /lib/x86_64-linux-gnu/libc-2.19.so
7f8990dd7000-7f8990ddc000 rw-p 00000000 00:00 0 
7f8990ddc000-7f8990df2000 r-xp 00000000 08:05 21495909                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7f8990df2000-7f8990ff1000 ---p 00016000 08:05 21495909                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7f8990ff1000-7f8990ff2000 r--p 00015000 08:05 21495909                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7f8990ff2000-7f8990ff3000 rw-p 00016000 08:05 21495909                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7f8990ff3000-7f89910f8000 r-xp 00000000 08:05 21500827                   /lib/x86_64-linux-gnu/libm-2.19.so
7f89910f8000-7f89912f7000 ---p 00105000 08:05 21500827                   /lib/x86_64-linux-gnu/libm-2.19.so
7f89912f7000-7f89912f8000 r--p 00104000 08:05 21500827                   /lib/x86_64-linux-gnu/libm-2.19.so
7f89912f8000-7f89912f9000 rw-p 00105000 08:05 21500827                   /lib/x86_64-linux-gnu/libm-2.19.so
7f89912f9000-7f89913ff000 r-xp 00000000 08:05 4738584                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22
7f89913ff000-7f89915fe000 ---p 00106000 08:05 4738584                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22
7f89915fe000-7f8991606000 r--p 00105000 08:05 4738584                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22
7f8991606000-7f8991608000 rw-p 0010d000 08:05 4738584                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22
7f8991608000-7f899160b000 rw-p 00000000 00:00 0 
7f899160b000-7f8991624000 r-xp 00000000 08:05 21500851                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f8991624000-7f8991823000 ---p 00019000 08:05 21500851                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f8991823000-7f8991824000 r--p 00018000 08:05 21500851                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f8991824000-7f8991825000 rw-p 00019000 08:05 21500851                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f8991825000-7f8991829000 rw-p 00000000 00:00 0 
7f8991829000-7f899182c000 r-xp 00000000 08:05 4726448                    /usr/lib/x86_64-linux-gnu/libboost_system.so.1.54.0
7f899182c000-7f8991a2b000 ---p 00003000 08:05 4726448                    /usr/lib/x86_64-linux-gnu/libboost_system.so.1.54.0
7f8991a2b000-7f8991a2c000 r--p 00002000 08:05 4726448                    /usr/lib/x86_64-linux-gnu/libboost_system.so.1.54.0
7f8991a2c000-7f8991a2d000 rw-p 00003000 08:05 4726448                    /usr/lib/x86_64-linux-gnu/libboost_system.so.1.54.0
7f8991a2d000-7f8991a55000 r-xp 00000000 08:05 20447339                   /opt/ros/indigo/lib/librostime.so
7f8991a55000-7f8991c54000 ---p 00028000 08:05 20447339                   /opt/ros/indigo/lib/librostime.so
7f8991c54000-7f8991c56000 r--p 00027000 08:05 20447339                   /opt/ros/indigo/lib/librostime.so
7f8991c56000-7f8991c57000 rw-p 00029000 08:05 20447339                   /opt/ros/indigo/lib/librostime.so
7f8991c57000-7f8991c59000 r-xp 00000000 08:05 20447364                   /opt/ros/indigo/lib/libroscpp_serialization.so
7f8991c59000-7f8991e58000 ---p 00002000 08:05 20447364                   /opt/ros/indigo/lib/libroscpp_serialization.so
7f8991e58000-7f8991e59000 r--p 00001000 08:05 20447364                   /opt/ros/indigo/lib/libroscpp_serialization.so
7f8991e59000-7f8991e5a000 rw-p 00002000 08:05 20447364                   /opt/ros/indigo/lib/libroscpp_serialization.so
7f8991e5a000-7f8991e83000 r-xp 00000000 08:05 20447437                   /opt/ros/indigo/lib/librosconsole.so
7f8991e83000-7f8992083000 ---p 00029000 08:05 20447437                   /opt/ros/indigo/lib/librosconsole.so
7f8992083000-7f8992085000 r--p 00029000 08:05 20447437                   /opt/ros/indigo/lib/librosconsole.so
7f8992085000-7f8992086000 rw-p 0002b000 08:05 20447437                   /opt/ros/indigo/lib/librosconsole.so
7f8992086000-7f89921df000 r-xp 00000000 08:05 20447784                   /opt/ros/indigo/lib/libroscpp.so
7f89921df000-7f89923df000 ---p 00159000 08:05 20447784                   /opt/ros/indigo/lib/libroscpp.so
7f89923df000-7f89923e6000 r--p 00159000 08:05 20447784                   /opt/ros/indigo/lib/libroscpp.so
7f89923e6000-7f89923ea000 rw-p 00160000 08:05 20447784                   /opt/ros/indigo/lib/libroscpp.so
7f89923ea000-7f89923eb000 rw-p 00000000 00:00 0 
7f89923eb000-7f899240e000 r-xp 00000000 08:05 21500853                   /lib/x86_64-linux-gnu/ld-2.19.so
7f89925bf000-7f89925d4000 rw-p 00000000 00:00 0 
7f89925f2000-7f89925f3000 rw-p 00000000 00:00 0 
7f89925f3000-7f89925fa000 r--s 00000000 08:05 5115060                    /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
7f89925fa000-7f899260d000 rw-p 00000000 00:00 0 
7f899260d000-7f899260e000 r--p 00022000 08:05 21500853                   /lib/x86_64-linux-gnu/ld-2.19.so
7f899260e000-7f899260f000 rw-p 00023000 08:05 21500853                   /lib/x86_64-linux-gnu/ld-2.19.so
7f899260f000-7f8992610000 rw-p 00000000 00:00 0 
7ffdea2e5000-7ffdea308000 rw-p 00000000 00:00 0                          [stack]
7ffdea31f000-7ffdea321000 r--p 00000000 00:00 0                          [vvar]
7ffdea321000-7ffdea323000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
```
This failure, to my understanding is identical to #3 and is caused when the `changeMotorSpeed` function is called. The cause of the failure is the size of the `cmd` and `speed` buffers being smaller than required - the size does not account for the string terminating  `\0` character.

The compiler warning that led to this bugfix is as follows:

```
In function ‘char* strcpy(char*, const char*)’,
    inlined from ‘void SweepDriver::_getSpeedValue(uint8_t, char*)’ at /home/bhavya/Maidbot/catkin_ws/src/sweep-ros/sweep-sdk-cpp/src/sweep_driver.cc:684:32,
    inlined from ‘status SweepDriver::changeMotorSpeed(uint8_t)’ at /home/bhavya/Maidbot/catkin_ws/src/sweep-ros/sweep-sdk-cpp/src/sweep_driver.cc:268:33:
/usr/include/x86_64-linux-gnu/bits/string3.h:104:63: warning: call to void* __builtin___memcpy_chk(void*, const void*, long unsigned int, long unsigned int) will always overflow destination buffer [enabled by default]
   return __builtin___strcpy_chk (__dest, __src, __bos (__dest));
```