### PR TITLE
Add missing dependencies and address some catkin_lint issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 
 include_directories(
-	include ${catkin_INCLUDE_DIRS}
-        ${PCL_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${PCL_INCLUDE_DIRS}
 )
 
 ## Add link directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,11 @@ project(sweep_ros)
 
 find_package(catkin REQUIRED
   COMPONENTS
+    pcl_conversions
+    pcl_msgs
     rosconsole
     roscpp
     sensor_msgs
-    pcl_msgs
-    pcl_conversions
 )
 
 find_package(PCL REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sweep_ros)
 
-find_package(catkin REQUIRED COMPONENTS
-        rosconsole
-        roscpp
-        sensor_msgs
-        pcl_msgs
-        pcl_conversions
-        )
+find_package(catkin REQUIRED
+  COMPONENTS
+    rosconsole
+    roscpp
+    sensor_msgs
+    pcl_msgs
+    pcl_conversions
+)
 
 find_package(PCL REQUIRED)
 find_package(Sweep REQUIRED)
@@ -23,10 +24,12 @@ include_directories(
 
 ## Add link directories
 link_directories(
-        ${PCL_LIBRARY_DIRS}
+  ${PCL_LIBRARY_DIRS}
 )
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS sensor_msgs
+)
 
 add_executable(sweep_node src/node.cpp)
 
@@ -38,4 +41,4 @@ install(TARGETS sweep_node
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-        )
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
         roscpp
         sensor_msgs
         pcl_msgs
+        pcl_conversions
         )
 
 find_package(PCL REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
     <build_depend>roscpp</build_depend>
     <build_depend>sensor_msgs</build_depend>
     <build_depend>pcl_conversions</build_depend>
+    <build_depend>pcl_msgs</build_depend>
     <run_depend>pcl_conversions</run_depend>
     <run_depend>rosconsole</run_depend>
     <run_depend>roscpp</run_depend>


### PR DESCRIPTION
Hello Scanse team,

In this PR I've addressed a relatively significant issue, which is that `pcl_conversions` was missing from the list of `catkin` `COMPONENTS`. This results in the following build error (under certain circumstances):

```
Starting  >>> sweep_ros
____________________________________________________________________________________________________________________________________________
Errors     << sweep_ros:make /usr/src/sweep_ws/logs/sweep_ros/build.make.002.log
<command-line>:0:15: warning: ISO C99 requires whitespace after the macro name
/usr/src/sweep_ws/src/sweep-ros/src/node.cpp:29:45: fatal error: pcl_conversions/pcl_conversions.h: No such file or directory
 #include "pcl_conversions/pcl_conversions.h"
                                             ^
compilation terminated.
make[2]: *** [CMakeFiles/sweep_node.dir/src/node.cpp.o] Error 1
make[1]: *** [CMakeFiles/sweep_node.dir/all] Error 2
make: *** [all] Error 2
cd /usr/src/sweep_ws/build/sweep_ros; catkin build --get-env sweep_ros | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
............................................................................................................................................
Failed     << sweep_ros:make                    [ Exited with code 2 ]
Failed    <<< sweep_ros                         [ 2 minutes and 9.2 seconds ]
```

In addition, I've addressed a few less significant issues that [`catkin_lint`](https://github.com/fkie/catkin_lint) pointed out. This is the list of all errors and warnings (I only fixed the errors and some superficial styling things):

```
sweep_ros $ catkin_lint .
sweep_ros: error: build include path 'include' does not exist
sweep_ros: error: missing build_depend on 'pcl_msgs'
sweep_ros: error: unconfigured build_depend on 'pcl_conversions'
sweep_ros: warning: package 'sensor_msgs' should be listed in catkin_package()
sweep_ros: CMakeLists.txt(15): warning: variable CMAKE_C_FLAGS is modified
sweep_ros: CMakeLists.txt(16): warning: variable CMAKE_CXX_FLAGS is modified
sweep_ros: CMakeLists.txt(24): warning: use of link_directories() is strongly discouraged
catkin_lint: checked 1 packages and found 7 problems
catkin_lint: 2 notices have been ignored. Use -W2 to see them
```