### PR TITLE
Upate CMakeLists.txt file to compile on Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(Sweep REQUIRED)
 find_package(Threads REQUIRED)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -Wextra")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 
 include_directories(
   ${catkin_INCLUDE_DIRS}


### PR DESCRIPTION
Per https://github.com/PointCloudLibrary/pcl/issues/3104 the current
pcl requires C++ Standard 14, not 11